### PR TITLE
context param resolve to correct prop + removed attribute listener on widget config

### DIFF
--- a/microfrontends/another-mfe-config/public/index.html
+++ b/microfrontends/another-mfe-config/public/index.html
@@ -54,13 +54,12 @@
     <script>
       function injectConfigIntoMfe() {
         fetch('%PUBLIC_URL%/mfe-config.json').then(async response => {
-          const config = await response.text()
-          const anotherMfeEl = document.getElementsByTagName('another-mfe-config')[0]
-          anotherMfeEl.setAttribute('config', config)
+          const config = await response.json();
+          const anotherMfeEl = document.getElementsByTagName('another-mfe-config')[0];
+          anotherMfeEl.config = config;
         })
       }
-
-      injectConfigIntoMfe()
+      window.onload = () => injectConfigIntoMfe()
     </script>
   </body>
 </html>

--- a/microfrontends/another-mfe-config/src/custom-elements/AnotherMfeConfigElement.js
+++ b/microfrontends/another-mfe-config/src/custom-elements/AnotherMfeConfigElement.js
@@ -2,11 +2,6 @@ import './public-path';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import AnotherMfeConfig from '../AnotherMfeConfig';
-
-const ATTRIBUTES = {
-  config: 'config'
-}
-
 class AnotherMfeConfigElement extends HTMLElement {
   constructor() {
     super();
@@ -14,25 +9,10 @@ class AnotherMfeConfigElement extends HTMLElement {
     this.mountPoint = null;
   }
 
-  static get observedAttributes() {
-    return Object.values(ATTRIBUTES);
-  }
-
   connectedCallback() {
     this.mountPoint = document.createElement('div');
     this.appendChild(this.mountPoint);
-    setTimeout(() => this.render(), 500);
-  }
-
-  attributeChangedCallback(attribute, oldValue, newValue) {
-    if (!AnotherMfeConfigElement.observedAttributes.includes(attribute)) {
-      throw new Error(`Untracked changed attributes: ${attribute}`)
-    }
-    if (this.mountPoint && newValue !== oldValue) {
-      setTimeout(() => {
-        this.config = JSON.parse(newValue);
-      }, 500);
-    }
+    this.render();
   }
 
   get config() {

--- a/microfrontends/another-mfe/public/mfe-config.json
+++ b/microfrontends/another-mfe/public/mfe-config.json
@@ -10,7 +10,7 @@
         }
     },
     "contextParams": {
-        "page.code": "my_mfe_page"
+        "page_code": "my_mfe_page"
     },
     "params": {
         "username": "adionisi",

--- a/microfrontends/another-mfe/src/AnotherMfe.js
+++ b/microfrontends/another-mfe/src/AnotherMfe.js
@@ -64,7 +64,7 @@ function AnotherMfe({ config }) {
       {
         contextParams && (
           <>
-            <div>Page Code: <strong>{contextParams['page.code']}</strong></div>
+            <div>Page Code: <strong>{contextParams.page_code}</strong></div>
           </>
         )
       }


### PR DESCRIPTION
solves two issues:
 - on widget `another-mfe`, it was looking for `contextParams['page.code']` instead of `contextParams.page_code`. so now it will listen to page_code prop on contextParams
 - on widget config `another-mfe-config`, I have removed attribute listener for `config`. this will only listen to prop `config` since this is the prop that is required in app-builder widget configuration MFE loader